### PR TITLE
Update dependencies for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.1
+#  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "symfony/var-dumper": "~3.3|~4.0",
-        "nesbot/carbon": "^1.26 || ^2.00",
+        "php": "^7.2.5",
+        "symfony/var-dumper": "^5.0.5",
+        "nesbot/carbon": "^2.31.0",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~7.0",
-        "squizlabs/php_codesniffer": "^2.3",
-        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.4",
+        "mockery/mockery": "^1.3.1",
         "moontoast/math": "^1.1"
     },
     "autoload": {


### PR DESCRIPTION
Updated dependencies for Laravel 7.

## Description
Removed PHP 7.1 from travis.yml as Laravel 7 uses PHP 7.2.5
Updated dependencies to newer versions as Laravel 7 uses newer versions of `phpunit`, `carbon`, etc.